### PR TITLE
use absolute URL to prevent 404 error

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
     <ul class="blog-gallery">
 
         <li class="blog-item" data-category="design history education">
-            <a href="graphpaper.substack.com" target="_blank" class="blog-link">
+            <a href="https://graphpaper.substack.com" target="_blank" class="blog-link">
                 <h3>Graph Paper</h3>
                 <p>On the conventional and unconventional ways people use charts.</p>
             </a>


### PR DESCRIPTION
Thanks for including the newsletter. I noticed the link wasn't working like the others because it was being interpreted as relative URL.